### PR TITLE
change "oracle" name with "aggregator"

### DIFF
--- a/contracts/aggregator-oracle/EdgeAggregatorOracle.sol
+++ b/contracts/aggregator-oracle/EdgeAggregatorOracle.sol
@@ -25,7 +25,7 @@ contract EdgeAggregatorOracle is IAggregatorOracle, Proof {
     }
 
     /* 
-     * @dev submit submits a new request to the oracle
+     * @dev submit submits a new request to the aggregator
      * @param _cid is the cid of the data segment
      * @return the transaction ID
      */


### PR DESCRIPTION
Oracle and the Aggregator contract means the same smart contract (that implements IAggregatorOracle.sol). using "oracle" may cause confusion.